### PR TITLE
Refactor routing logic

### DIFF
--- a/controller/health.go
+++ b/controller/health.go
@@ -1,0 +1,14 @@
+package controller
+
+import (
+	"fmt"
+	"net/http"
+)
+
+const (
+	welcomeMessage = "Hello from Source Academy Stories!"
+)
+
+func HandleHealthCheck(w http.ResponseWriter, r *http.Request) {
+	fmt.Fprint(w, welcomeMessage)
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -24,8 +24,10 @@ func Setup(config *config.Config) chi.Router {
 	// Define routes
 	r.Get("/", controller.HandleHealthCheck)
 
-	r.Get("/stories", controller.GetStories)
-	r.Post("/stories", controller.CreateStory)
+	r.Route("/stories", func(r chi.Router) {
+		r.Get("/", controller.GetStories)
+		r.Post("/", controller.CreateStory)
+	})
 
 	return r
 }

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,0 +1,40 @@
+package router
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-chi/chi/middleware"
+	"github.com/go-chi/chi/v5"
+	"github.com/go-chi/cors"
+	"github.com/source-academy/stories-backend/controller"
+	"github.com/source-academy/stories-backend/internal/config"
+	"github.com/source-academy/stories-backend/internal/utils/constants"
+)
+
+const (
+	WELCOME_MESSAGE = "Hello from Source Academy Stories!"
+)
+
+func Setup(config *config.Config) chi.Router {
+	r := chi.NewRouter()
+	r.Use(middleware.Logger)
+	// Handle CORS
+	options := cors.Options{
+		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
+	}
+	if config.Environment == constants.ENV_DEVELOPMENT {
+		options.AllowedOrigins = []string{"https://*", "http://*"}
+	}
+	r.Use(cors.Handler(options))
+
+	// Define routes
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w, WELCOME_MESSAGE)
+	})
+
+	r.Get("/stories", controller.GetStories)
+	r.Post("/stories", controller.CreateStory)
+
+	return r
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -1,19 +1,12 @@
 package router
 
 import (
-	"fmt"
-	"net/http"
-
 	"github.com/go-chi/chi/middleware"
 	"github.com/go-chi/chi/v5"
 	"github.com/go-chi/cors"
 	"github.com/source-academy/stories-backend/controller"
 	"github.com/source-academy/stories-backend/internal/config"
 	"github.com/source-academy/stories-backend/internal/utils/constants"
-)
-
-const (
-	WELCOME_MESSAGE = "Hello from Source Academy Stories!"
 )
 
 func Setup(config *config.Config) chi.Router {
@@ -29,9 +22,7 @@ func Setup(config *config.Config) chi.Router {
 	r.Use(cors.Handler(options))
 
 	// Define routes
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, WELCOME_MESSAGE)
-	})
+	r.Get("/", controller.HandleHealthCheck)
 
 	r.Get("/stories", controller.GetStories)
 	r.Post("/stories", controller.CreateStory)

--- a/main.go
+++ b/main.go
@@ -5,17 +5,9 @@ import (
 	"log"
 	"net/http"
 
-	"github.com/go-chi/chi/middleware"
-	"github.com/go-chi/chi/v5"
-	"github.com/go-chi/cors"
-	"github.com/source-academy/stories-backend/controller"
 	"github.com/source-academy/stories-backend/internal/config"
 	"github.com/source-academy/stories-backend/internal/database"
-	"github.com/source-academy/stories-backend/internal/utils/constants"
-)
-
-const (
-	WELCOME_MESSAGE = "Hello from Source Academy Stories!"
+	"github.com/source-academy/stories-backend/internal/router"
 )
 
 func main() {
@@ -32,25 +24,8 @@ func main() {
 	}
 	defer database.Close(db)
 
-	// TODO: Abstract router setup logic
-	r := chi.NewRouter()
-	r.Use(middleware.Logger)
-	// Handle CORS
-	options := cors.Options{
-		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
-	}
-	if conf.Environment == constants.ENV_DEVELOPMENT {
-		options.AllowedOrigins = []string{"https://*", "http://*"}
-	}
-	r.Use(cors.Handler(options))
-
-	// Define routes
-	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
-		fmt.Fprint(w, WELCOME_MESSAGE)
-	})
-
-	r.Get("/stories", controller.GetStories)
-	r.Post("/stories", controller.CreateStory)
+	// Setup router
+	r := router.Setup(conf)
 
 	// Start server
 	log.Printf("Starting server on %s port %d", conf.Host, conf.Port)


### PR DESCRIPTION
By moving the router setup logic into a separate package, we can abstract the setup process better from the main server initialization, and also future-proof the code in preparation for addition of more routes.