### PR TITLE
Refactor Env and DB constants to own packages

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,8 @@ import (
 
 	"github.com/joho/godotenv"
 	"github.com/sirupsen/logrus"
-	"github.com/source-academy/stories-backend/internal/utils/constants"
+	dbutils "github.com/source-academy/stories-backend/internal/utils/db"
+	envutils "github.com/source-academy/stories-backend/internal/utils/env"
 )
 
 type Config struct {
@@ -44,10 +45,10 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 	config := &Config{}
 
 	// Environment
-	if os.Getenv(GO_ENV) == constants.ENV_DEVELOPMENT {
-		config.Environment = constants.ENV_DEVELOPMENT
+	if os.Getenv(GO_ENV) == envutils.ENV_DEVELOPMENT {
+		config.Environment = envutils.ENV_DEVELOPMENT
 	} else {
-		config.Environment = constants.ENV_PRODUCTION
+		config.Environment = envutils.ENV_PRODUCTION
 	}
 
 	// Database
@@ -58,10 +59,10 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 		Password:     os.Getenv(DB_PASSWORD),
 		DatabaseName: os.Getenv(DB_NAME),
 	}
-	dbConfig.Port, err = parseIntFromEnv(DB_PORT, constants.DB_DEFAULT_PORT)
+	dbConfig.Port, err = parseIntFromEnv(DB_PORT, dbutils.DB_DEFAULT_PORT)
 	if err != nil {
 		logrus.Warningln("Invalid database port:", err)
-		logrus.Warningln("Using default database port:", constants.DB_DEFAULT_PORT)
+		logrus.Warningln("Using default database port:", dbutils.DB_DEFAULT_PORT)
 	}
 	config.Database = dbConfig
 
@@ -70,10 +71,10 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 
 	// Server configuration
 	config.Host = os.Getenv(HOST)
-	config.Port, err = parseIntFromEnv(PORT, constants.DEFAULT_PORT)
+	config.Port, err = parseIntFromEnv(PORT, envutils.DEFAULT_PORT)
 	if err != nil {
 		logrus.Warningln("Invalid server port:", err)
-		logrus.Warningln("Using default server port:", constants.DEFAULT_PORT)
+		logrus.Warningln("Using default server port:", envutils.DEFAULT_PORT)
 	}
 
 	return config, nil

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/joho/godotenv"
-	"github.com/source-academy/stories-backend/internal/utils/constants"
+	envutils "github.com/source-academy/stories-backend/internal/utils/env"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -33,19 +33,19 @@ func TestLoadFromEnvironment_AppEnvironment(t *testing.T) {
 		envFile, cleanUp := setupEnvFile(t, map[string]string{})
 		defer cleanUp(t)
 
-		os.Setenv(GO_ENV, constants.ENV_DEVELOPMENT)
+		os.Setenv(GO_ENV, envutils.ENV_DEVELOPMENT)
 		conf, err := LoadFromEnvironment(envFile)
 		assert.Nil(t, err)
-		assert.Equal(t, constants.ENV_DEVELOPMENT, conf.Environment)
+		assert.Equal(t, envutils.ENV_DEVELOPMENT, conf.Environment)
 	})
 	t.Run("should return production environment when GO_ENV is production", func(t *testing.T) {
 		envFile, cleanUp := setupEnvFile(t, map[string]string{})
 		defer cleanUp(t)
 
-		os.Setenv(GO_ENV, constants.ENV_PRODUCTION)
+		os.Setenv(GO_ENV, envutils.ENV_PRODUCTION)
 		conf, err := LoadFromEnvironment(envFile)
 		assert.Nil(t, err)
-		assert.Equal(t, constants.ENV_PRODUCTION, conf.Environment)
+		assert.Equal(t, envutils.ENV_PRODUCTION, conf.Environment)
 	})
 	t.Run("should return production environment when GO_ENV anything that is not development", func(t *testing.T) {
 		envFile, cleanUp := setupEnvFile(t, map[string]string{})
@@ -54,7 +54,7 @@ func TestLoadFromEnvironment_AppEnvironment(t *testing.T) {
 		os.Setenv(GO_ENV, "anything")
 		conf, err := LoadFromEnvironment(envFile)
 		assert.Nil(t, err)
-		assert.Equal(t, constants.ENV_PRODUCTION, conf.Environment)
+		assert.Equal(t, envutils.ENV_PRODUCTION, conf.Environment)
 	})
 }
 
@@ -116,7 +116,7 @@ func TestLoadFromEnvironment_FileEnvironment_Port_Unset(t *testing.T) {
 
 		conf, err := LoadFromEnvironment(envFile)
 		assert.Nil(t, err)
-		assert.Equal(t, constants.DEFAULT_PORT, conf.Port)
+		assert.Equal(t, envutils.DEFAULT_PORT, conf.Port)
 	})
 	t.Run("should return default port when it is set to an empty string", func(t *testing.T) {
 		envFile, cleanUp := setupEnvFile(t, map[string]string{
@@ -126,7 +126,7 @@ func TestLoadFromEnvironment_FileEnvironment_Port_Unset(t *testing.T) {
 
 		conf, err := LoadFromEnvironment(envFile)
 		assert.Nil(t, err)
-		assert.Equal(t, constants.DEFAULT_PORT, conf.Port)
+		assert.Equal(t, envutils.DEFAULT_PORT, conf.Port)
 	})
 }
 
@@ -150,7 +150,7 @@ func TestLoadFromEnvironment_FileEnvironment_Port_Set(t *testing.T) {
 
 		conf, err := LoadFromEnvironment(envFile)
 		assert.Nil(t, err)
-		assert.Equal(t, constants.DEFAULT_PORT, conf.Port)
+		assert.Equal(t, envutils.DEFAULT_PORT, conf.Port)
 	})
 }
 

--- a/internal/database/connect_test.go
+++ b/internal/database/connect_test.go
@@ -5,7 +5,8 @@ import (
 	"testing"
 
 	"github.com/source-academy/stories-backend/internal/config"
-	"github.com/source-academy/stories-backend/internal/utils/constants"
+	dbutils "github.com/source-academy/stories-backend/internal/utils/db"
+	envutils "github.com/source-academy/stories-backend/internal/utils/env"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -14,16 +15,16 @@ func ignoreError(func() (err error)) {}
 
 func TestConnect(t *testing.T) {
 	// TODO: Set up postgres container for testing in CI
-	if os.Getenv(config.GO_ENV) == constants.ENV_TEST {
+	if os.Getenv(config.GO_ENV) == envutils.ENV_TEST {
 		t.Skip("Skipping database connection tests in CI environment")
 	}
 
 	conf := &config.DatabaseConfig{
-		TimeZone:     constants.DB_DEFAULT_TIMEZONE,
+		TimeZone:     dbutils.DB_DEFAULT_TIMEZONE,
 		Host:         "localhost",
-		Port:         constants.DB_DEFAULT_PORT,
+		Port:         dbutils.DB_DEFAULT_PORT,
 		User:         "postgres",
-		DatabaseName: constants.DB_DEFAULT_NAME,
+		DatabaseName: dbutils.DB_DEFAULT_NAME,
 	}
 
 	t.Run("should connect to database", func(t *testing.T) {
@@ -40,7 +41,7 @@ func TestConnect(t *testing.T) {
 		// Get currently connected database name
 		var dbName string
 		db.Raw("SELECT current_database()").Scan(&dbName)
-		assert.Equal(t, constants.DB_DEFAULT_NAME, dbName)
+		assert.Equal(t, dbutils.DB_DEFAULT_NAME, dbName)
 	})
 	// TODO: Populate these with actual tables once schema is finalized
 	// t.Run("should show a correct list of tables", func(t *testing.T) {

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-chi/cors"
 	"github.com/source-academy/stories-backend/controller"
 	"github.com/source-academy/stories-backend/internal/config"
-	"github.com/source-academy/stories-backend/internal/utils/constants"
+	envutils "github.com/source-academy/stories-backend/internal/utils/env"
 )
 
 func Setup(config *config.Config, injectMiddleWares []func(http.Handler) http.Handler) chi.Router {
@@ -23,7 +23,7 @@ func Setup(config *config.Config, injectMiddleWares []func(http.Handler) http.Ha
 	options := cors.Options{
 		AllowedMethods: []string{"GET", "POST", "PUT", "DELETE", "OPTIONS"},
 	}
-	if config.Environment == constants.ENV_DEVELOPMENT {
+	if config.Environment == envutils.ENV_DEVELOPMENT {
 		options.AllowedOrigins = []string{"https://*", "http://*"}
 	}
 	r.Use(cors.Handler(options))

--- a/internal/utils/db/constants.go
+++ b/internal/utils/db/constants.go
@@ -1,4 +1,4 @@
-package constants
+package dbutils
 
 const (
 	// TODO: Fall back to these values if the environment variables are not set

--- a/internal/utils/env/constants.go
+++ b/internal/utils/env/constants.go
@@ -1,4 +1,4 @@
-package constants
+package envutils
 
 const (
 	ENV_DEVELOPMENT = "development"

--- a/main.go
+++ b/main.go
@@ -11,7 +11,7 @@ import (
 	"github.com/source-academy/stories-backend/internal/config"
 	"github.com/source-academy/stories-backend/internal/database"
 	"github.com/source-academy/stories-backend/internal/router"
-	"github.com/source-academy/stories-backend/internal/utils/constants"
+	envutils "github.com/source-academy/stories-backend/internal/utils/env"
 
 	"github.com/source-academy/stories-backend/model"
 	"gorm.io/gorm"
@@ -36,7 +36,7 @@ func main() {
 
 	var injectMiddlewares []func(http.Handler) http.Handler
 	// Initialze Sentry configuration
-	if conf.Environment == constants.ENV_PRODUCTION {
+	if conf.Environment == envutils.ENV_PRODUCTION {
 		err := sentry.Init(sentry.ClientOptions{
 			Dsn: conf.SentryDSN,
 			// Set TracesSampleRate to 1.0 to capture 100%


### PR DESCRIPTION
Allows for further extension of each utils' package with e.g. utility functions.

Part of #14.