### PR TITLE
Refactor server config environment variables and error handling

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -35,11 +35,8 @@ const (
 )
 
 func LoadFromEnvironment(envFiles ...string) (*Config, error) {
-	err := godotenv.Load(envFiles...)
-	if err != nil {
-		logrus.Errorln("Error loading .env file:", err)
-		return nil, err
-	}
+	var err error
+	loadEnvFiles(envFiles...)
 
 	config := &Config{}
 
@@ -78,6 +75,23 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 	}
 
 	return config, nil
+}
+
+// Populates the environment from variables
+// in the given files. If a file does not exist,
+// it will be ignored (with a warning).
+func loadEnvFiles(envFiles ...string) {
+	// We manually iterate through each file path
+	// because godotenv.Load() will stop at the first
+	// error it encounters.
+	for _, filePath := range envFiles {
+		err := godotenv.Load(filePath)
+		if err == nil {
+			logrus.Warningf("Error loading env file %s: %v. Skipping...\n", filePath, err)
+			continue
+		}
+		logrus.Infoln("Loaded environment from", filePath)
+	}
 }
 
 func getEnvOrDefault(key string, fallback string) string {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -82,7 +82,7 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 
 func getEnvOrDefault(key string, fallback string) string {
 	if value, ok := os.LookupEnv(key); ok {
-		return value // Includes empty string
+		return value // Includes empty string if set
 	}
 	return fallback
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,11 +52,12 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 
 	// Database
 	dbConfig := &DatabaseConfig{
-		TimeZone:     os.Getenv(DB_TIMEZONE),
-		Host:         os.Getenv(DB_HOSTNAME),
-		User:         os.Getenv(DB_USERNAME),
-		Password:     os.Getenv(DB_PASSWORD),
-		DatabaseName: os.Getenv(DB_NAME),
+		// Port handled below
+		TimeZone:     getEnvOrDefault(DB_TIMEZONE, constants.DB_DEFAULT_TIMEZONE),
+		Host:         getEnvOrDefault(DB_HOSTNAME, constants.DB_DEFAULT_HOSTNAME),
+		User:         getEnvOrDefault(DB_USERNAME, constants.DB_DEFAULT_USER),
+		Password:     getEnvOrDefault(DB_PASSWORD, constants.DB_DEFAULT_PASSWORD),
+		DatabaseName: getEnvOrDefault(DB_NAME, constants.DB_DEFAULT_NAME),
 	}
 	dbConfig.Port, err = parseIntFromEnv(DB_PORT, constants.DB_DEFAULT_PORT)
 	if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -79,13 +79,21 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 	return config, nil
 }
 
+func getEnvOrDefault(key string, fallback string) string {
+	if value, ok := os.LookupEnv(key); ok {
+		return value // Includes empty string
+	}
+	return fallback
+}
+
 // Parses an integer from the environment variable with the given key.
 // If the environment variable is not set, it returns the default
 // value. If the environment variable is set but cannot be parsed as
 // an integer, it returns an error as well as setting the return value
 // to the default value.
 func parseIntFromEnv(key string, defaultValue int) (int, error) {
-	strVal := os.Getenv(key)
+	// FIXME: Hacky abstraction
+	strVal := getEnvOrDefault(key, strconv.Itoa(defaultValue))
 	if strVal == "" {
 		return defaultValue, nil
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -51,11 +51,11 @@ func LoadFromEnvironment(envFiles ...string) (*Config, error) {
 	// Database
 	dbConfig := &DatabaseConfig{
 		// Port handled below
-		TimeZone:     getEnvOrDefault(DB_TIMEZONE, constants.DB_DEFAULT_TIMEZONE),
-		Host:         getEnvOrDefault(DB_HOSTNAME, constants.DB_DEFAULT_HOSTNAME),
-		User:         getEnvOrDefault(DB_USERNAME, constants.DB_DEFAULT_USER),
-		Password:     getEnvOrDefault(DB_PASSWORD, constants.DB_DEFAULT_PASSWORD),
-		DatabaseName: getEnvOrDefault(DB_NAME, constants.DB_DEFAULT_NAME),
+		TimeZone:     getEnvOrDefault(DB_TIMEZONE, dbutils.DB_DEFAULT_TIMEZONE),
+		Host:         getEnvOrDefault(DB_HOSTNAME, dbutils.DB_DEFAULT_HOSTNAME),
+		User:         getEnvOrDefault(DB_USERNAME, dbutils.DB_DEFAULT_USER),
+		Password:     getEnvOrDefault(DB_PASSWORD, dbutils.DB_DEFAULT_PASSWORD),
+		DatabaseName: getEnvOrDefault(DB_NAME, dbutils.DB_DEFAULT_NAME),
 	}
 	dbConfig.Port, err = parseIntFromEnv(DB_PORT, dbutils.DB_DEFAULT_PORT)
 	if err != nil {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,9 +59,9 @@ func TestLoadFromEnvironment_AppEnvironment(t *testing.T) {
 }
 
 func TestLoadFromEnvironment_FileEnvironment(t *testing.T) {
-	t.Run("should throw error when environment file not found", func(t *testing.T) {
+	t.Run("should not throw error when environment file not found", func(t *testing.T) {
 		_, err := LoadFromEnvironment("non-existent-file")
-		assert.NotNil(t, err)
+		assert.Nil(t, err)
 	})
 	t.Run("should load a valid environment file without errors", func(t *testing.T) {
 		envFile, cleanUp := setupEnvFile(t, map[string]string{

--- a/internal/utils/constants/db.go
+++ b/internal/utils/constants/db.go
@@ -3,6 +3,9 @@ package constants
 const (
 	// TODO: Fall back to these values if the environment variables are not set
 	DB_DEFAULT_TIMEZONE = "Asia/Singapore"
+	DB_DEFAULT_HOSTNAME = "localhost"
+	DB_DEFAULT_USER     = "postgres"
+	DB_DEFAULT_PASSWORD = ""
 	DB_DEFAULT_PORT     = 5432
 	DB_DEFAULT_NAME     = "sa-stories"
 )


### PR DESCRIPTION
* Use get-or-default methods to set fallback values for missing environment variables
* When an environment file path is not found, do not return errors; instead simply skip them (with a warning)

This improves testability by reducing the amount of setup and/or boilerplate code required.