### PR TITLE
Update Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,9 @@ hooks:
 	@echo "Hooks installed successfully!"
 
 db_migrate: db_status
-	@GO_ENV=development go run ${DB_SCRIPT_ENTRYPOINT} migrate $(steps)
+	@go run ${DB_SCRIPT_ENTRYPOINT} migrate $(steps)
 db_rollback:
-	@GO_ENV=development go run ${DB_SCRIPT_ENTRYPOINT} rollback $(steps)
+	@go run ${DB_SCRIPT_ENTRYPOINT} rollback $(steps)
 	@$(MAKE) db_status
 db_status:
-	@GO_ENV=development go run ${DB_SCRIPT_ENTRYPOINT} status
+	@go run ${DB_SCRIPT_ENTRYPOINT} status

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ OUTPUT_PATH=./app
 DB_SCRIPT_ENTRYPOINT=./scripts/db.go
 DB_TARGETS=db_migrate db_rollback db_status
 
-.PHONY: dev build test testCI coverage lint format hooks $(DB_TARGETS)
+.PHONY: dev build test coverage lint format hooks $(DB_TARGETS)
 
 dev:
 	@GO_ENV=development go run ${PROGRAM_ENTRYPOINT}


### PR DESCRIPTION
* Remove deprecated target
* Remove `GO_ENV` value from DB targets
  * This was unnecessary for DB script to occur, and I also feel that ideally the DB script should be agnostic of this particular environment setting