### PR TITLE
Fix environment files not being loaded

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,7 +87,7 @@ func loadEnvFiles(envFiles ...string) {
 	// error it encounters.
 	for _, filePath := range envFiles {
 		err := godotenv.Load(filePath)
-		if err == nil {
+		if err != nil {
 			logrus.Warningf("Error loading env file %s: %v. Skipping...\n", filePath, err)
 			continue
 		}

--- a/main.go
+++ b/main.go
@@ -21,7 +21,8 @@ var DB *gorm.DB
 
 func main() {
 	// Load configuration
-	conf, err := config.LoadFromEnvironment()
+	// FIXME: Remove hardcoding when further configuration is added
+	conf, err := config.LoadFromEnvironment(".env")
 	if err != nil {
 		logrus.Errorln(err)
 	}


### PR DESCRIPTION
Turns out, there were two problems introduced in #38:

* Incorrect messages (log messages are opposite of the outcome)
* Now that we handle each file individually, we need to manually specify the default environment filepath (`.env`)