### PR TITLE
Inject DB session to request context via middleware

### DIFF
--- a/internal/database/middleware.go
+++ b/internal/database/middleware.go
@@ -7,15 +7,18 @@ import (
 	"gorm.io/gorm"
 )
 
+// We define our own type to avoid collisions
+type contextKey string
+
 const (
-	contextKey = "database_context"
+	dbKey contextKey = "database_context"
 )
 
 func MakeMiddlewareFrom(db *gorm.DB) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Create a new session from the database for each request
-			ctx := context.WithValue(r.Context(), contextKey, db.Session(&gorm.Session{}))
+			ctx := context.WithValue(r.Context(), dbKey, db.Session(&gorm.Session{}))
 			// Inject the new context into the request
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})

--- a/internal/database/middleware.go
+++ b/internal/database/middleware.go
@@ -1,0 +1,23 @@
+package database
+
+import (
+	"context"
+	"net/http"
+
+	"gorm.io/gorm"
+)
+
+const (
+	contextKey = "database_context"
+)
+
+func MakeMiddlewareFrom(db *gorm.DB) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Create a new session from the database for each request
+			ctx := context.WithValue(r.Context(), contextKey, db.Session(&gorm.Session{}))
+			// Inject the new context into the request
+			next.ServeHTTP(w, r.WithContext(ctx))
+		})
+	}
+}

--- a/main.go
+++ b/main.go
@@ -35,6 +35,10 @@ func main() {
 	defer database.Close(DB)
 
 	var injectMiddlewares []func(http.Handler) http.Handler
+
+	// Inject DB session into request context
+	injectMiddlewares = append(injectMiddlewares, database.MakeMiddlewareFrom(DB))
+
 	// Initialze Sentry configuration
 	if conf.Environment == envutils.ENV_PRODUCTION {
 		err := sentry.Init(sentry.ClientOptions{

--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ func main() {
 	}
 
 	// Connect to the database
+	// FIXME: Don't use a global variable
 	DB, err = database.Connect(conf.Database)
 	model.DB = DB
 	if err != nil {


### PR DESCRIPTION
Part of #33.

This will allow controllers to access the current DB session (that is now unique for each request) from the request context.

This means that even if a session is closed, a subsequent request will still get a new DB session as the single source of generated sessions is never exposed (once the global variable is converted back to private).