### PR TITLE
Use API error handler for stories

### DIFF
--- a/controller/stories/stories.go
+++ b/controller/stories/stories.go
@@ -74,6 +74,15 @@ func HandleCreate(w http.ResponseWriter, r *http.Request) error {
 			Message: fmt.Sprintf("Invalid JSON format: %s should be a %s.", e.Field, e.Type),
 		}
 	}
+
+	err := params.Validate()
+	if err != nil {
+		logrus.Error(err)
+		return apierrors.ClientUnprocessableEntityError{
+			Message: fmt.Sprintf("JSON validation failed: %v", err),
+		}
+	}
+
 	storyModel := *params.ToModel()
 
 	// Get DB instance

--- a/internal/errors/422.go
+++ b/internal/errors/422.go
@@ -1,0 +1,17 @@
+package apierrors
+
+import (
+	"net/http"
+)
+
+type ClientUnprocessableEntityError struct {
+	Message string
+}
+
+func (e ClientUnprocessableEntityError) Error() string {
+	return e.Message
+}
+
+func (e ClientUnprocessableEntityError) HTTPStatusCode() int {
+	return http.StatusUnprocessableEntity
+}

--- a/internal/router/router.go
+++ b/internal/router/router.go
@@ -37,9 +37,9 @@ func Setup(config *config.Config, injectMiddleWares []func(http.Handler) http.Ha
 	r.Group(func(r chi.Router) {
 		r.Use(auth.MakeMiddlewareFrom(config))
 		r.Route("/stories", func(r chi.Router) {
-			r.Get("/", stories.HandleList)
-			r.Get("/{storyID}", stories.HandleRead)
-			r.Post("/", stories.HandleCreate)
+			r.Get("/", handleAPIError(stories.HandleList))
+			r.Get("/{storyID}", handleAPIError(stories.HandleRead))
+			r.Post("/", handleAPIError(stories.HandleCreate))
 		})
 
 		r.Route("/users", func(r chi.Router) {

--- a/model/stories.go
+++ b/model/stories.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/source-academy/stories-backend/internal/database"
 	"gorm.io/gorm"
 )
 
@@ -10,18 +11,28 @@ type Story struct {
 	Content  string
 }
 
-func GetAllStories(db *gorm.DB) []Story {
+func GetAllStories(db *gorm.DB) ([]Story, error) {
 	var stories []Story
-	db.Find(&stories)
-	return stories
+	err := db.Find(&stories).Error
+	if err != nil {
+		return stories, database.HandleDBError(err, "story")
+	}
+	return stories, nil
 }
 
-func GetStoryByID(db *gorm.DB, id int) Story {
+func GetStoryByID(db *gorm.DB, id int) (Story, error) {
 	var story Story
-	db.First(&story, id)
-	return story
+	err := db.First(&story, id).Error
+	if err != nil {
+		return story, database.HandleDBError(err, "story")
+	}
+	return story, nil
 }
 
-func CreateStory(db *gorm.DB, story *Story) {
-	db.Create(story)
+func CreateStory(db *gorm.DB, story *Story) error {
+	err := db.Create(story).Error
+	if err != nil {
+		return database.HandleDBError(err, "story")
+	}
+	return nil
 }

--- a/model/stories_test.go
+++ b/model/stories_test.go
@@ -74,7 +74,7 @@ func TestGetStoryByID(t *testing.T) {
 		}
 
 		for _, storyToAdd := range stories {
-			CreateStory(db, storyToAdd)
+			_ = CreateStory(db, storyToAdd)
 		}
 
 		for _, story := range stories {

--- a/model/stories_test.go
+++ b/model/stories_test.go
@@ -32,7 +32,8 @@ func TestCreateStory(t *testing.T) {
 		db, cleanUp := setupDBConnection(t, dbConfig)
 		defer cleanUp(t)
 
-		initialStories := GetAllStories(db)
+		initialStories, err := GetAllStories(db)
+		assert.Nil(t, err, "Expected no error when getting all stories")
 
 		// We need to first create a user due to the foreign key constraint
 		user := User{
@@ -45,9 +46,11 @@ func TestCreateStory(t *testing.T) {
 			AuthorID: user.ID,
 			Content:  "# Hi\n\nThis is a test story.",
 		}
-		CreateStory(db, &story)
+		err = CreateStory(db, &story)
+		assert.Nil(t, err, "Expected no error when creating story")
 
-		newStories := GetAllStories(db)
+		newStories, err := GetAllStories(db)
+		assert.Nil(t, err, "Expected no error when getting all stories")
 		assert.Len(t, newStories, len(initialStories)+1, "Expected number of stories to increase by 1")
 
 		var lastStory Story
@@ -76,7 +79,8 @@ func TestGetStoryByID(t *testing.T) {
 
 		for _, story := range stories {
 			// FIXME: Don't use typecast
-			dbStory := GetStoryByID(db, int(story.ID))
+			dbStory, err := GetStoryByID(db, int(story.ID))
+			assert.Nil(t, err, "Expected no error when getting story with valid ID")
 			assert.Equal(t, story.ID, dbStory.ID, fmt.Sprintf(expectReadEqualMessage, "story"))
 			assert.Equal(t, story.AuthorID, dbStory.AuthorID, fmt.Sprintf(expectReadEqualMessage, "story"))
 			assert.Equal(t, story.Content, dbStory.Content, fmt.Sprintf(expectReadEqualMessage, "story"))


### PR DESCRIPTION
Uses the error handling framework introduced in #50 for the stories MVC. Similar to #59.

Also adds a 422 Unprocessable Entity client error type. Note that this is inconsistent behaviour with #59 as that returns a 400 on bad JSON unmarshall. This is wrong and will be refactored once both PRs are merged. Ideally,

* 400: Bad JSON parsing
* 422: Bad JSON unmarshall/param validation.

The validate method that was missed for users and will be added once #58 is merged also needs to be refactored to use the correct status code.