### PR TITLE
Bump Golang to 1.21.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.53.3
+          version: v1.55.2
       - name: Ensure ordering of migration files is preserved
         if: ${{ github.event_name == 'pull_request' }}
         run: |

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
-golang 1.20.5
+golang 1.21.5
 postgres 14.8

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Install Golang and PostgresSQL. We recommend using a version manager like [asdf]
 * Install the required versions of the tools:
 
   ```bash
-  asdf install golang 1.20.5
+  asdf install golang 1.21.5
   asdf install postgres 14.8
   ```
 

--- a/deployment/api/Dockerfile
+++ b/deployment/api/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5 AS build_stage
+FROM golang:1.21.5 AS build_stage
 
 WORKDIR /go/src/github.com/source-academy/
 

--- a/deployment/migrator/Dockerfile
+++ b/deployment/migrator/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.5
+FROM golang:1.21.5
 
 # Needed for pg_isready
 RUN apt-get update

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/source-academy/stories-backend
 
-go 1.20
+go 1.21
 
 require (
 	github.com/TwiN/go-color v1.4.0


### PR DESCRIPTION
Closes #117.

See https://github.com/golangci/golangci-lint/issues/3718 for more info.